### PR TITLE
append button to header-actions

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,10 +47,8 @@ function addBulkButton(app, html) {
     const forGm = game.settings.get(moduleName, 'gmOnly');
     if (forGm && !game.user.isGM) {return;} 
 
-    if((app.options.id == "scenes" || app.options.id == "actors" 
-        || app.options.id == "items" || app.options.id == "journal" 
-        || app.options.id == "tables")){
-        let button = $("<div class='header-actions action-buttons flexrow'><button><i class='fas fa-edit'></i></i> Bulk Tasks</button></div>");
+    if(['scenes', 'actors', 'items', 'journal', 'tables', 'playlists', 'macros-popout'].includes(app.tabName)){
+        let button = $("<button class='bulk-tasks'><i class='fas fa-edit'></i></i> Bulk Tasks</button>");
         
         button.click(async () => {
             // Render Menu
@@ -59,7 +57,7 @@ function addBulkButton(app, html) {
     
 
         // Render Button
-        $(html).find(".directory-header").append(button);
+        $(html).find(".header-actions").append(button);
     }
 
 

--- a/styles/module.css
+++ b/styles/module.css
@@ -20,6 +20,11 @@
     color: white;
 }
 
+/* Ensures buttons in action-buttons do not shrink */
+.action-buttons button {
+    min-width: max-content;
+    white-space: nowrap;
+}
 
 /* Main Menu Content css */
 .bm-collapsable {


### PR DESCRIPTION
- Instead of creating a whole new `header-actions` DOM element (which has compatibility issues with other modules), append your one button to the existing header-actions element.
- Ensure that header-actions elements do not shrink and do wrap
- Adds button to Macro Directory and Playlist Directory. Also does this for popped out tabs.