### PR TITLE
Support bulk import with folders and keep IDs.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -35,7 +35,8 @@
 					"GMOnly": "GM Only",
 					"all": "Everyone"
 				}
-			}
+			},
+			"keepIdsOnImport": { "title": "Keep IDs on Import" }
 		}
 	},
 	"BM.deleteTitle": "Delete Selected",

--- a/src/managers/TaskManager.ts
+++ b/src/managers/TaskManager.ts
@@ -244,13 +244,17 @@ class BulkTasksManager {
 		// Prepare data
 		const importData: Record<string, any[]> = documents.reduce((acc, data) => {
 			const type = inferDocumentType(data);
-			console.log(type);
-			if (!type) return;
+			console.log(`${data._id} = ${type}`);
+			if (!type) return acc;
 
 			acc[type] ??= [];
 			acc[type].push(data);
 			return acc;
 		}, {});
+
+		let operation = {};
+		if (game.settings?.get(moduleId, 'keepIdsOnImport') as boolean)
+			operation = { keepId: true, keepEmbeddedIds: true };
 
 		for await (const [type, docs] of Object.entries(importData)) {
 			const cls = CONFIG[type].documentClass;
@@ -261,7 +265,7 @@ class BulkTasksManager {
 			}
 
 			for await (const chunk of chunks) {
-				await cls.createDocuments(chunk);
+				await cls.createDocuments(chunk, operation);
 			}
 		}
 	}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -52,4 +52,12 @@ export function registerSettings() {
 		},
 		default: 'gmOnly',
 	});
+
+	game.settings?.register(moduleId, 'keepIdsOnImport', {
+		name: 'BulkTasks.settings.keepIdsOnImport.title',
+		scope: 'world',
+		config: true,
+		type: Boolean,
+		default: false,
+	});
 }

--- a/src/utils/extractFileContents.ts
+++ b/src/utils/extractFileContents.ts
@@ -6,8 +6,10 @@ export async function extractFileContents(file: File) {
 		try {
 			const data = JSON.parse(content);
 
-			if (data.package) documents.push(...data.items);
-			else documents.push(data);
+			if (data.package) {
+				documents.push(...data.items);
+				documents.push(...data.folders);
+			} else documents.push(data);
 		} catch (err) {
 			console.warn(`Failed to parse datable due to bad entry: ${file.name}`);
 			console.error(err);

--- a/src/utils/inferDocumentType.ts
+++ b/src/utils/inferDocumentType.ts
@@ -37,6 +37,11 @@ const isRollTable = (source: Record<string, any>): boolean => {
 	return 'results' in source && 'displayRoll' in source && 'replacement' in source;
 };
 
+const isFolder = (source: Record<string, any>): boolean => {
+	/* Refer to: https://foundryvtt.com/api/interfaces/foundry.types.FolderData.html */
+	return 'name' in source && 'type' in source && 'sorting' in source;
+};
+
 export function inferDocumentType(doc): string | undefined {
 	if (isActor(doc)) return 'Actor';
 	if (isItem(doc)) return 'Item';
@@ -45,5 +50,6 @@ export function inferDocumentType(doc): string | undefined {
 	if (isScene(doc)) return 'Scene';
 	if (isPlaylist(doc)) return 'Playlist';
 	if (isRollTable(doc)) return 'RollTable';
+	if (isFolder(doc)) return 'Folder';
 	return undefined;
 }


### PR DESCRIPTION
This feature adds the ability for the "Import" operation to import folders.  A folder JSON is detected through the presence of the `name`, `type`, and `sorting` fields.

This is intended for use with `package`-style imports, where the import JSON looks like:
```
{
  "package": { },
  "items": [
    { <Single Document 1> },
    { <Single Document 2> },
    { ... },
    { <Single Document N> },
  ],
  "folders": [
    { <Folder Document 1> },
    { <Folder Document 2> },
    { ... },
    { <Folder Document N> },
  ]
}
```

The import will now gather both the `items` and `folders` array for import.

In order for an import to place files into folders, the import needs to maintain the Foundry IDs.  A new option for keeping IDs has been added to the module settings to enable correct linking on import. If this option is not enabled, all the folders will be imported but assigned new IDs.