### PR TITLE
Clear documents after delete.

### DIFF
--- a/src/view/Delete.svelte
+++ b/src/view/Delete.svelte
@@ -11,6 +11,7 @@ import SecondaryNav from './components/SecondaryNav.svelte';
 
 async function deleteDocs() {
 	await BulkTasksManager.deleteDocuments(new Set(selected));
+	selected.clear();
 	directory = buildDirectory(currentSecondaryTab);
 }
 


### PR DESCRIPTION
The list of documents passed to `BulkTasksManager.deleteDocuments` must be cleared otherwise deleted documents stay in the `selected` list.

This causes future deletes to fail with an exception being thrown when attempting to delete a non-existing folder.