### PR TITLE
Export supports JSON packages.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -25,7 +25,7 @@
 				"hint": ""
 			},
 			"defaultExportNamingConvention": { "title": "Default File Naming Convention for Exports." },
-			"defaultExportZipName": { "title": "Default Zip Name for Exports." },
+			"defaultExportFileName": { "title": "Default File Name for Exports." },
 			"defaultDuplicateNamingConvention": { "title": "Default Naming Convention for Duplicates." },
 			"defaultRenameNamingConvention": { "title": "Default File Naming Convention for Renames." },
 			"permDefaultName": {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,8 +9,16 @@ export function registerSettings() {
 		default: '{foundry}',
 	});
 
+	/*
+	 * The name 'defaultExportZipName' originates from a time when only ZIP files
+	 * could be exported.  Even though this now applies to the file regardless of the
+	 * file format, the name has been maintained in order to ensure backwards
+	 * compatability with pre-existing configuration.
+	 *
+	 * Note that the name never included the '.zip' suffix.
+	 */
 	game.settings?.register(moduleId, 'defaultExportZipName', {
-		name: 'BulkTasks.settings.defaultExportZipName.title',
+		name: 'BulkTasks.settings.defaultExportFileName.title',
 		scope: 'world',
 		config: true,
 		type: String,

--- a/src/view/Export.svelte
+++ b/src/view/Export.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { SvelteSet } from 'svelte/reactivity';
 
-import { BulkTasksManager } from '../managers/TaskManager.ts';
+import { BulkTasksManager, ExportFileFormat } from '../managers/TaskManager.ts';
 import { buildDirectory } from '../utils/buildDirectory.ts';
 import { localize } from '../utils/localize.ts';
 
@@ -10,11 +10,13 @@ import FolderViewHeader from './components/FolderViewHeader.svelte';
 import SecondaryNav from './components/SecondaryNav.svelte';
 
 async function exportDocs() {
+	const exportFileFormat = exportFormat.id;
 	const options = {
 		namingConvention,
 		preserveFolders,
 		preserveMetaData,
-		zipName,
+		fileName,
+		exportFileFormat,
 	};
 
 	await BulkTasksManager.exportDocuments(new Set(selected), options);
@@ -22,13 +24,25 @@ async function exportDocs() {
 
 let { currentSecondaryTab } = $props();
 
+let exportFormatOptions = $state([
+	{
+		id: ExportFileFormat.Zip,
+		text: 'ZIP File',
+	},
+	{
+		id: ExportFileFormat.JsonPackage,
+		text: 'JSON Package File',
+	},
+]);
+
 let selected = new SvelteSet<string>();
 let directory = $state(buildDirectory(currentSecondaryTab));
 let namingConvention = $state(BulkTasksManager.DEFAULTS.EXPORT_NAMING_CONVENTION);
-let zipName = $state(BulkTasksManager.DEFAULTS.EXPORT_ZIP_NAME);
+let fileName = $state(BulkTasksManager.DEFAULTS.EXPORT_FILE_NAME);
 let preserveFolders = $state(true);
 let preserveMetaData = $state(true);
 let searchParam = $state('');
+let exportFormat = $state();
 </script>
 
 <section class="bm-dialog-body bm-dialog-body__export">
@@ -42,12 +56,25 @@ let searchParam = $state('');
 
     <div class="bm-config-view">
         <label class="bm-config-view__label">
-            <span> Zip Name </span>
+            <span> File Format </span>
+
+            <select bind:value={exportFormat}>
+                {#each exportFormatOptions as opt}
+                    <option value={opt}>
+                        {opt.text}
+                    </option>
+                {/each}
+            </select>
+
+        </label>
+
+        <label class="bm-config-view__label">
+            <span> File Name </span>
 
             <input
                 class="bm-config-view__input"
                 type="text"
-                bind:value={zipName}
+                bind:value={fileName}
             />
         </label>
 


### PR DESCRIPTION
This feature adds an new export file type, where export can now generate either a ZIP File or a JSON file.  The ZIP File generation is unchanged.

The JSON File provides a simple analog to the compendium `package` -style exports, allow export of both items and folders.

The output format looks like:
```
{
  "package": { },
  "items": [
    { <Single Document 1> },
    { <Single Document 2> },
    { ... },
    { <Single Document N> },
  ],
  "folders": [
    { <Folder Document 1> },
    { <Folder Document 2> },
    { ... },
    { <Folder Document N> },
  ]
}
```

The set of folders placed into the `folders` array is automatically discovered from the set of selected documents.  In order to maintain the correct linkage between the folder and the items, the `_id` field is injected into each output document.